### PR TITLE
chore: bump active-support to version 2.15.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.version>3.11.0</maven.compiler.version>
 
         <!-- DVSA Internal Libraries -->
-        <active-support.version>2.14.2</active-support.version>
+        <active-support.version>2.15.4</active-support.version>
         <uri-constructor.version>2.4.0</uri-constructor.version>
 
         <!-- Testing & API Libraries -->
@@ -108,7 +108,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.15.1</version>
+                <version>2.15.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <rest-assured.version>5.4.0</rest-assured.version>
 
         <!-- HTTP Client -->
-        <apache-http.version>5.3.1</apache-http.version>
+        <apache-http.version>5.5.1</apache-http.version>
 
         <!-- Utilities -->
         <commons-lang3.version>3.18.0</commons-lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.15.2</version>
+                <version>2.15.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
BREAKING CHANGE: Updated active-support dependency from 2.15.2 to 2.15.4

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
