### PR TITLE
fix: re-enable vehicle size declaration for PSV applications

### DIFF
--- a/src/main/java/apiCalls/actions/CreateApplication.java
+++ b/src/main/java/apiCalls/actions/CreateApplication.java
@@ -1384,25 +1384,26 @@ public class CreateApplication extends BaseAPI{
         return apiResponse;
     }
 
-    // NO LONGER USED
-//    public synchronized ValidatableResponse submitVehicleDeclaration() throws HttpException {
-//        if (licenceType.equals(LicenceType.SPECIAL_RESTRICTED.asString())) {
-//            return null;
-//        }
-//
-//        var vehicleDeclarationResource = ApiUrl.build(env, String.format(String.format("application/%s/vehicle-declaration/submit", applicationId))).toString();
-//        int applicationVersion = Integer.parseInt(fetchApplicationInformation(getApplicationId(), "version", "1"));
-//
-//        VehicleDeclarationBuilder vehicleDeclarationBuilder = new VehicleDeclarationBuilder().withId(getApplicationId()
-//                ).withPsvVehicleSize(psvVehicleSize)
-//                .withPsvLimousines(psvLimousines).withPsvNoSmallVhlConfirmation(psvNoSmallVhlConfirmation).withPsvOperateSmallVhl(psvOperateSmallVhl).withPsvSmallVhlNotes(psvSmallVhlNotes)
-//                .withPsvNoLimousineConfirmation(psvNoLimousineConfirmation).withPsvOnlyLimousinesConfirmation(psvOnlyLimousinesConfirmation).withVersion(applicationVersion);
-//        apiResponse = RestUtils.post(vehicleDeclarationBuilder, vehicleDeclarationResource, apiHeaders.getApiHeader());
-//
-//        Utils.checkHTTPStatusCode(apiResponse, HttpStatus.SC_OK);
-//
-//        return apiResponse;
-//    }
+    public synchronized ValidatableResponse submitVehicleDeclaration() throws HttpException {
+        if (licenceType.equals(LicenceType.SPECIAL_RESTRICTED.asString())) {
+            return null;
+        }
+        if (!operatorType.equals(OperatorType.PUBLIC.asString())) {
+            return null;
+        }
+
+        var vehicleSizeResource = ApiUrl.build(env, String.format("application/%s/vehicle-size", applicationId)).toString();
+        int applicationVersion = Integer.parseInt(fetchApplicationInformation(getApplicationId(), "version", "1"));
+
+        VehicleDeclarationBuilder vehicleDeclarationBuilder = new VehicleDeclarationBuilder().withId(getApplicationId())
+                .withPsvVehicleSize(psvVehicleSize)
+                .withVersion(applicationVersion);
+        apiResponse = RestUtils.put(vehicleDeclarationBuilder, vehicleSizeResource, apiHeaders.getApiHeader());
+
+        Utils.checkHTTPStatusCode(apiResponse, HttpStatus.SC_OK);
+
+        return apiResponse;
+    }
 
     public synchronized ValidatableResponse addFinancialHistory() throws HttpException {
         if (operatorType.equals(OperatorType.PUBLIC.asString()) && (licenceType.equals(LicenceType.SPECIAL_RESTRICTED.asString()))) {


### PR DESCRIPTION
The VehiclesSizeReviewService in vol-app expects psvWhichVehicleSizes to be set when generating a grant snapshot for PSV applications. Without this, granting a PSV licence fails with 'Trying to access array offset on null' in VehiclesSizeReviewService.php.

Updated the endpoint from the old vehicle-declaration/submit (POST) to the current vehicle-size (PUT) endpoint, sending only the required fields (id, psvVehicleSize, version).

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
