### PR TITLE
fix: remove vehicle size declaration call pending vol-app backend fix

### DIFF
--- a/src/main/java/apiCalls/actions/CreateApplication.java
+++ b/src/main/java/apiCalls/actions/CreateApplication.java
@@ -1384,26 +1384,25 @@ public class CreateApplication extends BaseAPI{
         return apiResponse;
     }
 
-    public synchronized ValidatableResponse submitVehicleDeclaration() throws HttpException {
-        if (licenceType.equals(LicenceType.SPECIAL_RESTRICTED.asString())) {
-            return null;
-        }
-        if (!operatorType.equals(OperatorType.PUBLIC.asString())) {
-            return null;
-        }
-
-        var vehicleSizeResource = ApiUrl.build(env, String.format("application/%s/vehicle-size", applicationId)).toString();
-        int applicationVersion = Integer.parseInt(fetchApplicationInformation(getApplicationId(), "version", "1"));
-
-        VehicleDeclarationBuilder vehicleDeclarationBuilder = new VehicleDeclarationBuilder().withId(getApplicationId())
-                .withPsvVehicleSize(psvVehicleSize)
-                .withVersion(applicationVersion);
-        apiResponse = RestUtils.put(vehicleDeclarationBuilder, vehicleSizeResource, apiHeaders.getApiHeader());
-
-        Utils.checkHTTPStatusCode(apiResponse, HttpStatus.SC_OK);
-
-        return apiResponse;
-    }
+    // NO LONGER USED
+//    public synchronized ValidatableResponse submitVehicleDeclaration() throws HttpException {
+//        if (licenceType.equals(LicenceType.SPECIAL_RESTRICTED.asString())) {
+//            return null;
+//        }
+//
+//        var vehicleDeclarationResource = ApiUrl.build(env, String.format(String.format("application/%s/vehicle-declaration/submit", applicationId))).toString();
+//        int applicationVersion = Integer.parseInt(fetchApplicationInformation(getApplicationId(), "version", "1"));
+//
+//        VehicleDeclarationBuilder vehicleDeclarationBuilder = new VehicleDeclarationBuilder().withId(getApplicationId()
+//                ).withPsvVehicleSize(psvVehicleSize)
+//                .withPsvLimousines(psvLimousines).withPsvNoSmallVhlConfirmation(psvNoSmallVhlConfirmation).withPsvOperateSmallVhl(psvOperateSmallVhl).withPsvSmallVhlNotes(psvSmallVhlNotes)
+//                .withPsvNoLimousineConfirmation(psvNoLimousineConfirmation).withPsvOnlyLimousinesConfirmation(psvOnlyLimousinesConfirmation).withVersion(applicationVersion);
+//        apiResponse = RestUtils.post(vehicleDeclarationBuilder, vehicleDeclarationResource, apiHeaders.getApiHeader());
+//
+//        Utils.checkHTTPStatusCode(apiResponse, HttpStatus.SC_OK);
+//
+//        return apiResponse;
+//    }
 
     public synchronized ValidatableResponse addFinancialHistory() throws HttpException {
         if (operatorType.equals(OperatorType.PUBLIC.asString()) && (licenceType.equals(LicenceType.SPECIAL_RESTRICTED.asString()))) {


### PR DESCRIPTION
The submitVehicleDeclaration() call is not needed as the root cause is a backend bug in vol-app where VehiclesSizeReviewService.php and YesNoType.php do not handle null values in PHP 8.3. The fix will be applied in vol-app instead.

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
