### PR TITLE
feat: add submitVehicleSize() for new PUT vehicle-size endpoint

### DIFF
--- a/src/main/java/apiCalls/Utils/volBuilders/VehicleSizeBuilder.java
+++ b/src/main/java/apiCalls/Utils/volBuilders/VehicleSizeBuilder.java
@@ -1,0 +1,32 @@
+package apiCalls.Utils.volBuilders;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class VehicleSizeBuilder {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("psvVehicleSize")
+    private String psvVehicleSize;
+
+    @JsonProperty("version")
+    private Integer version;
+
+    public VehicleSizeBuilder withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public VehicleSizeBuilder withPsvVehicleSize(String psvVehicleSize) {
+        this.psvVehicleSize = psvVehicleSize;
+        return this;
+    }
+
+    public VehicleSizeBuilder withVersion(Integer version) {
+        this.version = version;
+        return this;
+    }
+}

--- a/src/main/java/apiCalls/actions/CreateApplication.java
+++ b/src/main/java/apiCalls/actions/CreateApplication.java
@@ -974,7 +974,7 @@ public class CreateApplication extends BaseAPI{
         setCountryCode("GB");
 
         // PSV details
-        setPsvVehicleSize("psvvs_both");
+        setPsvVehicleSize("psvvs_medium_large");
         setPsvNoSmallVhlConfirmation("Y");
         setPsvOperateSmallVhl("Y");
         setPsvSmallVhlNotes("submitted through the API");
@@ -1384,25 +1384,24 @@ public class CreateApplication extends BaseAPI{
         return apiResponse;
     }
 
-    // NO LONGER USED
-//    public synchronized ValidatableResponse submitVehicleDeclaration() throws HttpException {
-//        if (licenceType.equals(LicenceType.SPECIAL_RESTRICTED.asString())) {
-//            return null;
-//        }
-//
-//        var vehicleDeclarationResource = ApiUrl.build(env, String.format(String.format("application/%s/vehicle-declaration/submit", applicationId))).toString();
-//        int applicationVersion = Integer.parseInt(fetchApplicationInformation(getApplicationId(), "version", "1"));
-//
-//        VehicleDeclarationBuilder vehicleDeclarationBuilder = new VehicleDeclarationBuilder().withId(getApplicationId()
-//                ).withPsvVehicleSize(psvVehicleSize)
-//                .withPsvLimousines(psvLimousines).withPsvNoSmallVhlConfirmation(psvNoSmallVhlConfirmation).withPsvOperateSmallVhl(psvOperateSmallVhl).withPsvSmallVhlNotes(psvSmallVhlNotes)
-//                .withPsvNoLimousineConfirmation(psvNoLimousineConfirmation).withPsvOnlyLimousinesConfirmation(psvOnlyLimousinesConfirmation).withVersion(applicationVersion);
-//        apiResponse = RestUtils.post(vehicleDeclarationBuilder, vehicleDeclarationResource, apiHeaders.getApiHeader());
-//
-//        Utils.checkHTTPStatusCode(apiResponse, HttpStatus.SC_OK);
-//
-//        return apiResponse;
-//    }
+    public synchronized ValidatableResponse submitVehicleSize() throws HttpException {
+        if (licenceType.equals(LicenceType.SPECIAL_RESTRICTED.asString())) {
+            return null;
+        }
+
+        var vehicleSizeResource = ApiUrl.build(env, String.format("application/%s/vehicle-size", applicationId)).toString();
+        int applicationVersion = Integer.parseInt(fetchApplicationInformation(getApplicationId(), "version", "1"));
+
+        VehicleSizeBuilder vehicleSizeBuilder = new VehicleSizeBuilder()
+                .withId(getApplicationId())
+                .withPsvVehicleSize(psvVehicleSize)
+                .withVersion(applicationVersion);
+        apiResponse = RestUtils.put(vehicleSizeBuilder, vehicleSizeResource, apiHeaders.getApiHeader());
+
+        Utils.checkHTTPStatusCode(apiResponse, HttpStatus.SC_OK);
+
+        return apiResponse;
+    }
 
     public synchronized ValidatableResponse addFinancialHistory() throws HttpException {
         if (operatorType.equals(OperatorType.PUBLIC.asString()) && (licenceType.equals(LicenceType.SPECIAL_RESTRICTED.asString()))) {


### PR DESCRIPTION
VOL-5882 removed the old vehicle-declaration/submit endpoint and replaced it with PUT application/{id}/vehicle-size. This adds:

- VehicleSizeBuilder class for the request body
- submitVehicleSize() method that calls PUT vehicle-size for PSV apps
- Default psvVehicleSize changed from psvvs_both to psvvs_medium_large (psvvs_both triggers a YesNoType null bug in vol-app PHP 8.3)

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
