### PR TITLE
fix: upgrade netty to 4.1.133.Final and active-support to 2.18.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.version>3.11.0</maven.compiler.version>
 
         <!-- DVSA Internal Libraries -->
-        <active-support.version>2.18.3</active-support.version>
+        <active-support.version>2.18.4</active-support.version>
         <uri-constructor.version>2.4.0</uri-constructor.version>
 
         <!-- Testing & API Libraries -->
@@ -59,37 +59,37 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http2</artifactId>
-                <version>4.1.132.Final</version>
+                <version>4.1.133.Final</version>
             </dependency>
 
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.132.Final</version>
+                <version>4.1.133.Final</version>
             </dependency>
 
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>
-                <version>4.1.129.Final</version>
+                <version>4.1.133.Final</version>
             </dependency>
 
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.129.Final</version>
+                <version>4.1.133.Final</version>
             </dependency>
 
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>
-                <version>4.1.129.Final</version>
+                <version>4.1.133.Final</version>
             </dependency>
 
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-buffer</artifactId>
-                <version>4.1.129.Final</version>
+                <version>4.1.133.Final</version>
             </dependency>
 
             <dependency>
@@ -101,7 +101,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver</artifactId>
-                <version>4.1.129.Final</version>
+                <version>4.1.133.Final</version>
             </dependency>
 
             <!-- Fix Commons IO vulnerability -->


### PR DESCRIPTION
Resolves multiple high-severity CVEs:
- Allocation of Resources Without Limits in io.netty:netty-codec-http2
- Improper Handling of Highly Compressed Data in io.netty:netty-codec-http2
- Allocation of Resources Without Limits in io.netty:netty-codec
- Improper Handling of Highly Compressed Data in io.netty:netty-codec
- Aligns all netty modules to 4.1.133.Final

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
